### PR TITLE
Add missing noncopyable class

### DIFF
--- a/noncopyable.hpp
+++ b/noncopyable.hpp
@@ -1,0 +1,15 @@
+#ifndef NONCOPYABLE_HPP
+#define NONCOPYABLE_HPP
+
+class noncopyable_t
+{
+  public:
+    noncopyable_t()  = default;
+    ~noncopyable_t() = default;
+
+  private:
+    noncopyable_t(const noncopyable_t&) = delete;
+    noncopyable_t& operator =(const noncopyable_t&) = delete;
+};
+
+#endif /* end of include guard: NONCOPYABLE_HPP */

--- a/wallpaper.cpp
+++ b/wallpaper.cpp
@@ -4,7 +4,6 @@
 
 #include <wayfire/compositor-view.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
-#include <wayfire/nonstd/noncopyable.hpp>
 #include <wayfire/opengl.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/render-manager.hpp>
@@ -33,6 +32,7 @@
 
 #include "clocks.hpp"
 #include "pid_fd_fork.h"
+#include "noncopyable.hpp"
 
 enum class sizing { fill, fit, stretch };
 


### PR DESCRIPTION
The noncopyable header doesn't exist in wayfire project anymore. In fact, i am not familiar with c++, but i attemp to make it to be compiled.

Related Issue: https://github.com/WayfireWM/wayfire/issues/1227
Related Commit: Ghttps://github.com/WayfireWM/wayfire/issues/1227